### PR TITLE
Update Vauxhall/Opel Insignia generations: Verified generation data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Vauxhall/Opel Insignia
 
+This repository contains signal set configurations for the Vauxhall/Opel Insignia, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Vauxhall/Opel Insignia.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,7 @@
+references:
+  - "https://en.wikipedia.org/wiki/Opel_Insignia"
+  - "https://en.wikipedia.org/wiki/Vauxhall_Insignia"
+
 generations:
   - name: "First Generation (Insignia A)"
     start_year: 2008


### PR DESCRIPTION
- Confirmed two generations from Wikipedia: First Gen (2008-2017), Second Gen (2017-present)
- 2013 facelift treated as visual update within First Generation (same Epsilon II platform)
- Added Wikipedia references for Opel Insignia and Vauxhall Insignia articles
- Updated README.md with standard template documentation
